### PR TITLE
Fix typo in GitHub

### DIFF
--- a/src/commands/System/links.js
+++ b/src/commands/System/links.js
@@ -7,7 +7,7 @@ exports.execute = async (client, message, args) => {
             + "[Support Server](https://discord.gg/jRN7SZB)\n"
             + "[Website](" + client.config.hostname + ")\n"
             + "[Privacy Policy](" + client.config.hostname + "/privacy)\n"
-            + "[Github](https://github.com/Chicken/ChickenBot)");
+            + "[GitHub](https://github.com/Chicken/ChickenBot)");
     message.channel.send(embed);
 };
   


### PR DESCRIPTION
Fix very important issue: Github -> GitHub

<!-- Link a GitHub issue if exists -->
Closes #

**Description**

<!--
Quick recap of the closed issue or a detailed description of the feature.
Can be omitted for bug fixes.
-->
This has been causing major issues for many users, the hub in GitHub was not capitalized in the links command.

**Changes**

<!-- Quick summary of changes using a list -->
- Github -> GitHub
